### PR TITLE
Replace sextant byte rendering with ASCII display and configurable co…

### DIFF
--- a/cli/lib/terminal/app.js
+++ b/cli/lib/terminal/app.js
@@ -24,7 +24,7 @@ export class TerminalApp {
         this.layout = new Layout();
 
         // Panes
-        this.memoryPane = new MemoryPane(controller.memory);
+        this.memoryPane = new MemoryPane(controller.memory, controller);
         this.disasmPane = new DisasmPane(controller);
         this.commandPane = new CommandPane();
         this.minimapPane = new MinimapPane(controller, visualizer);
@@ -240,6 +240,7 @@ export class TerminalApp {
     step() {
         this.controller.runToNextInterrupt();
         this.totalInterrupts++;
+        this.memoryPane.invalidatePC();
         this.needsRender = true;
     }
 
@@ -251,6 +252,7 @@ export class TerminalApp {
                 this.controller.runToNextInterrupt();
                 this.totalInterrupts++;
             }
+            this.memoryPane.invalidatePC();
             this.needsRender = true;
         }
 
@@ -259,6 +261,10 @@ export class TerminalApp {
             this.render();
             this.lastRender = now;
             this.needsRender = false;
+        } else if (!this.needsRender) {
+            // Cursor flash: partial redraw without full screen render
+            const flashOut = this.memoryPane.renderCursorFlash(this.layout.memory);
+            if (flashOut) process.stdout.write(flashOut);
         }
 
         setImmediate(() => this.tick());

--- a/cli/lib/terminal/pane-memory.js
+++ b/cli/lib/terminal/pane-memory.js
@@ -9,8 +9,10 @@
 // of the scheduler's iOrig/jOrig and is controlled by the user.
 
 import { moveTo, ESC, reset, dim, bold } from '../ansi.js';
-import { byteToSextant, byteColor, BORDER_COLOR, CURSOR_COLOR_ON, CURSOR_COLOR_OFF, hsvToRGB } from './sextant.js';
+import { byteToSextant, byteColor, BORDER_COLOR, CURSOR_COLOR_ON, CURSOR_COLOR_OFF, hsvToRGB,
+         byteToAsciiChar, DEFAULT_ASCII_PALETTE } from './sextant.js';
 import { hex16 } from './disassembler.js';
+import { readCellRegisters } from '../../../engine/board.js';
 
 // Build the spiral layout: map (gridX, gridY) → cell index for the 7x7 neighborhood
 // Using the same spiral order as memory.js
@@ -69,8 +71,9 @@ function gridToAddr(col, row) {
 }
 
 export class MemoryPane {
-    constructor(memory) {
+    constructor(memory, controller) {
         this.memory = memory;
+        this.controller = controller;
         // The board cell whose 7x7 neighborhood we're displaying
         this.centerI = 0;
         this.centerJ = 0;
@@ -80,9 +83,18 @@ export class MemoryPane {
         // Cursor position in the grid
         this.cursorCol = 3 * 32;
         this.cursorRow = 3 * 32;
-        // Flash state
+        // Flash state (250ms cursor blink)
         this.flashOn = true;
         this.lastFlash = 0;
+        // Configurable palette
+        this.palette = { ...DEFAULT_ASCII_PALETTE };
+        // Cached PC grid positions (set of "col,row" strings for fast lookup)
+        this._pcPositions = new Map(); // "col,row" → cellIdx
+        this._pcDirty = true;
+        // Last rendered cursor position (for partial redraw)
+        this._lastCursorScreenCol = -1;
+        this._lastCursorScreenRow = -1;
+        this._lastRect = null;
     }
 
     get cursorAddr() {
@@ -93,6 +105,7 @@ export class MemoryPane {
     setCenter(i, j) {
         this.centerI = ((i % this.memory.B) + this.memory.B) % this.memory.B;
         this.centerJ = ((j % this.memory.B) + this.memory.B) % this.memory.B;
+        this._pcDirty = true;
     }
 
     // Move the center cell (and keep cursor at same relative position within grid)
@@ -100,6 +113,7 @@ export class MemoryPane {
         const B = this.memory.B;
         this.centerI = (this.centerI + di + B) % B;
         this.centerJ = (this.centerJ + dj + B) % B;
+        this._pcDirty = true;
     }
 
     // Move cursor by delta
@@ -183,18 +197,108 @@ export class MemoryPane {
         return { addr, cellIdx, byteOff, boardI, boardJ, gx, gy };
     }
 
+    // Mark PC positions as needing recomputation (call after stepping/running)
+    invalidatePC() {
+        this._pcDirty = true;
+    }
+
+    // Recompute the set of grid positions where each neighbor's PC points
+    _refreshPCPositions() {
+        this._pcPositions.clear();
+        if (!this.controller) { this._pcDirty = false; return; }
+        const B = this.memory.B;
+        for (let cellIdx = 0; cellIdx < 49; cellIdx++) {
+            const [dx, dy] = spiralVec[cellIdx];
+            const i = (this.centerI + dx + B) % B;
+            const j = (this.centerJ + dy + B) % B;
+            const regs = readCellRegisters(this.controller, i, j);
+            const pc = regs.PC;
+            // PC is in the memory-mapped address space; convert to grid position
+            // PC addresses are cell-local (0x000-0x3FF), within this cell's address range
+            const addr = (cellIdx << 10) | (pc & 0x3FF);
+            const pos = addrToGrid(addr);
+            if (pos) {
+                this._pcPositions.set(`${pos.col},${pos.row}`, cellIdx);
+            }
+        }
+        this._pcDirty = false;
+    }
+
+    // Render a single cell at the given grid position, returning the ANSI string
+    _renderCell(gridCol, gridRow, isCursor, flashOn) {
+        const pal = this.palette;
+        const fg = (r, g, b) => `\x1b[38;2;${r};${g};${b}m`;
+        const bg = (r, g, b) => `\x1b[48;2;${r};${g};${b}m`;
+
+        if (gridRow < 0 || gridRow >= 224 || gridCol < 0 || gridCol >= 224) {
+            return reset + ' ';
+        }
+        const addr = gridToAddr(gridCol, gridRow);
+        if (addr < 0) return reset + ' ';
+
+        const byte = this.readByteAt(gridCol, gridRow);
+        const { char, fg: fgColor } = byteToAsciiChar(byte, pal);
+
+        // Determine background color
+        const isOnBorder = (gridCol % 32 === 31) || (gridRow % 32 === 31);
+        const pcKey = `${gridCol},${gridRow}`;
+        const pcCellIdx = this._pcPositions.get(pcKey);
+        let bgColor;
+        if (pcCellIdx !== undefined) {
+            bgColor = pcCellIdx === 0 ? pal.bgCenterPC : pal.bgPC;
+        } else if (isOnBorder) {
+            bgColor = pal.bgBorder;
+        } else {
+            bgColor = pal.bgDefault;
+        }
+
+        if (isCursor && flashOn) {
+            // Inverse: swap fg and bg
+            return fg(...bgColor) + bg(...fgColor) + char + reset;
+        } else {
+            return fg(...fgColor) + bg(...bgColor) + char + reset;
+        }
+    }
+
+    // Render just the cursor cell (old and new positions) for flash updates
+    renderCursorFlash(rect) {
+        if (!this._lastRect) return '';
+
+        const now = Date.now();
+        const newFlash = (now - this.lastFlash > 250);
+        if (!newFlash) return '';
+
+        this.flashOn = !this.flashOn;
+        this.lastFlash = now;
+
+        let out = '';
+        const cursorScreenCol = this.cursorCol - this.scrollX;
+        const cursorScreenRow = this.cursorRow - this.scrollY;
+
+        // Redraw current cursor position
+        if (cursorScreenCol >= 0 && cursorScreenCol < rect.width &&
+            cursorScreenRow >= 0 && cursorScreenRow < rect.height) {
+            out += moveTo(rect.row + cursorScreenRow, rect.col + cursorScreenCol);
+            out += this._renderCell(this.cursorCol, this.cursorRow, true, this.flashOn);
+        }
+
+        return out;
+    }
+
     render(rect) {
         const now = Date.now();
-        if (now - this.lastFlash > 400) {
+        if (now - this.lastFlash > 250) {
             this.flashOn = !this.flashOn;
             this.lastFlash = now;
         }
 
         this.ensureCursorVisible(rect);
+        this._lastRect = rect;
+
+        // Refresh PC positions if needed
+        if (this._pcDirty) this._refreshPCPositions();
 
         let out = '';
-        const fg = (r, g, b) => `\x1b[38;2;${r};${g};${b}m`;
-        const bg = (r, g, b) => `\x1b[48;2;${r};${g};${b}m`;
 
         for (let screenRow = 0; screenRow < rect.height; screenRow++) {
             out += moveTo(rect.row + screenRow, rect.col);
@@ -202,33 +306,14 @@ export class MemoryPane {
 
             for (let screenCol = 0; screenCol < rect.width; screenCol++) {
                 const gridCol = this.scrollX + screenCol;
-
-                if (gridRow < 0 || gridRow >= 224 || gridCol < 0 || gridCol >= 224) {
-                    out += ' ';
-                    continue;
-                }
-
-                const addr = gridToAddr(gridCol, gridRow);
-                if (addr < 0) {
-                    out += ' ';
-                    continue;
-                }
-
                 const isCursor = (gridCol === this.cursorCol && gridRow === this.cursorRow);
-                const isOnCellBorderX = (gridCol % 32 === 31);
-                const isOnCellBorderY = (gridRow % 32 === 31);
 
-                const byte = this.readByteAt(gridCol, gridRow);
-                const ch = byteToSextant(byte);
-                const [cr, cg, cb] = byteColor(byte);
-
-                if (isCursor && this.flashOn) {
-                    out += fg(0, 0, 0) + bg(255, 255, 0) + ch + reset;
-                } else if (isOnCellBorderX || isOnCellBorderY) {
-                    out += fg(cr, cg, cb) + bg(...BORDER_COLOR) + ch + reset;
-                } else {
-                    out += fg(cr, cg, cb) + ch + reset;
+                if (isCursor) {
+                    this._lastCursorScreenCol = rect.col + screenCol;
+                    this._lastCursorScreenRow = rect.row + screenRow;
                 }
+
+                out += this._renderCell(gridCol, gridRow, isCursor, this.flashOn);
             }
         }
 

--- a/cli/lib/terminal/sextant.js
+++ b/cli/lib/terminal/sextant.js
@@ -73,4 +73,50 @@ export const BORDER_COLOR = [80, 80, 120];
 export const CURSOR_COLOR_ON = [255, 255, 0];
 export const CURSOR_COLOR_OFF = [180, 180, 0];
 
+// --- ASCII byte rendering palette ---
+// Configurable color palette for ASCII byte display mode.
+// Low bytes (0-127) use: normal, zero, control colors.
+// High bytes (128-255) mask out bit 7 and use: highNormal, highZero, highControl.
+export const DEFAULT_ASCII_PALETTE = {
+    normal:     [255, 255, 255], // white — printable ASCII (33-126)
+    zero:       [100, 100, 100], // gray  — space (32), shown as underscore
+    control:    [255, 80,  80],  // red   — control chars (1-31) and DEL (127)
+    highNormal: [255, 165, 0],   // orange — high-bit printable (161-254 → 33-126)
+    highZero:   [255, 255, 100], // yellow — high-bit space (160 → 32)
+    highControl:[255, 130, 180], // pink   — high-bit control (129-159, 255)
+    bgDefault:  [0,   0,   0],   // black  — normal background
+    bgBorder:   [50,  90,  50],  // light green — cell boundary background
+    bgPC:       [0,   0,   100], // dark blue — neighbor cell PC background
+    bgCenterPC: [0,   140, 140], // cyan — central cell PC background
+};
+
+// Convert a byte to { char, fg } using the ASCII palette rules.
+// char: the character to display
+// fg: [r,g,b] foreground color
+export function byteToAsciiChar(byte, palette = DEFAULT_ASCII_PALETTE) {
+    const high = byte >= 128;
+    const low = high ? byte & 0x7F : byte;
+
+    let char, fg;
+    if (low === 0) {
+        char = ' ';
+        fg = high ? palette.highNormal : palette.normal; // won't be visible anyway
+    } else if (low >= 1 && low <= 31) {
+        char = String.fromCharCode(low + 64);
+        fg = high ? palette.highControl : palette.control;
+    } else if (low === 32) {
+        char = '_';
+        fg = high ? palette.highZero : palette.zero;
+    } else if (low >= 33 && low <= 126) {
+        char = String.fromCharCode(low);
+        fg = high ? palette.highNormal : palette.normal;
+    } else {
+        // 127 (DEL)
+        char = '?';
+        fg = high ? palette.highControl : palette.control;
+    }
+
+    return { char, fg };
+}
+
 export { SEXTANT };


### PR DESCRIPTION
…lor palette

Bytes now render as ASCII characters with color-coded foreground:
- 33-126: white printable ASCII; 32: gray underscore; 0: space
- 1-31: red control chars (displayed as char+64); 127: red '?'
- 128-255: same rules with high bit masked, using orange/yellow/pink

Background colors indicate context:
- Black for normal cells, light green for cell boundaries
- Dark blue for neighbor cell PC addresses, cyan for central cell PC

Cursor flashes to inverse (fg/bg swap) every 250ms via partial redraw to avoid full screen repaints. Palette is fully configurable via memoryPane.palette object.

https://claude.ai/code/session_01FxtpKQ4D5yDM8ShewqSkFb