### PR TITLE
Fix "what is this?" link not working on mobile

### DIFF
--- a/webgpu/index.html
+++ b/webgpu/index.html
@@ -974,7 +974,7 @@ The board is initialized by default with one such self-replicating seed; you can
 
         // --- Chrome iOS fix: click events not synthesized from touch ---
         // Use pointerup directly for interactive elements instead of onclick.
-        $('whatLink').onclick = (e) => { e.preventDefault(); const p = $('whatPanel'); p.style.display = p.style.display === 'none' ? '' : 'none'; };
+        onTap($('whatLink'), (e) => { e.preventDefault(); const p = $('whatPanel'); p.style.display = p.style.display === 'none' ? '' : 'none'; });
 
         function onTap(el, fn) {
             let _touchFired = false;


### PR DESCRIPTION
Use onTap() instead of onclick for the whatLink element, matching the
pattern already used for toggle button and other interactive elements.
On Chrome iOS, click events aren't synthesized from touch when the
board is running, so pointerup handling is needed.

https://claude.ai/code/session_011hqaC5tASh11h5D5ihZqv8